### PR TITLE
chore: update deps.

### DIFF
--- a/.github/workflows/check-code.yaml
+++ b/.github/workflows/check-code.yaml
@@ -56,7 +56,6 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.22"
           - "1.23"
           - "1.24"
     steps:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,8 @@ linters:
   disable:
     - "depguard"
     - "varnamelen"
+    # deprecated linters
+    - "wsl"
   settings:
     cyclop:
       max-complexity: 20

--- a/README.jp.md
+++ b/README.jp.md
@@ -118,7 +118,7 @@ func main() {
 
 ## Requirements
 
-- Go 1.22 以上.
+- Go 1.23 以上.
 - Docker (開発時)
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ func main() {
 
 ## Requirements
 
-- Go 1.22 or above.
+- Go 1.23 or above.
 - Docker (for Development)
 
 ## Install

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mythrnr/errors
 
-go 1.22
+go 1.23
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
This pull request updates the Go version used in the project from 1.22 to 1.23 and removes a deprecated linter from the configuration. Below is a summary of the most important changes:

### Go Version Upgrade

* [`.github/workflows/check-code.yaml`](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L59): Removed Go 1.22 from the matrix and ensured compatibility with Go 1.23 and 1.24.
* `README.md` and `README.jp.md`: Updated the "Requirements" section to reflect the minimum required Go version as 1.23 instead of 1.22. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L123-R123) [[2]](diffhunk://#diff-1be2acdcd3d0a8bc52d6c676aea011d0a834cb1214f0ea54ad9b84cba155c6efL121-R121)
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the `go` directive from 1.22 to 1.23.

### Linter Configuration

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R12-R13): Added the deprecated linter `wsl` to the disable list.