### PR TITLE
chore: update deps, use any instead interface{}.

### DIFF
--- a/.github/workflows/check-code.yaml
+++ b/.github/workflows/check-code.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9" # v8.0.0
+      - uses: "golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601" # v9.1.0
         with:
           version: "latest"
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
       - name: "Run spell check"
         run: "make spell-check"
@@ -46,9 +46,9 @@ jobs:
           - "1.24"
           - "1.25"
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00" # v6.0.0
+      - uses: "actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c" # v6.1.0
         with:
           go-version: "${{ matrix.go }}"
 

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -15,9 +15,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
+      - uses: "actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3" # v6.0.0
 
-      - uses: "actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00" # v6.0.0
+      - uses: "actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c" # v6.1.0
         with:
           go-version: "1.25"
 

--- a/error.go
+++ b/error.go
@@ -2,14 +2,14 @@ package errors
 
 type stdError interface {
 	error
-	As(target interface{}) bool
+	As(target any) bool
 	Is(err error) bool
 	Unwrap() error
 }
 
 type stdJoinError interface {
 	error
-	As(target interface{}) bool
+	As(target any) bool
 	Is(err error) bool
 	Unwrap() []error
 }
@@ -43,7 +43,7 @@ func Wrap(err, cause error) error {
 //
 // As は `target` に代入可能な値を `e.main` , `e.cause` の優先順位で探し,
 // 代入できた場合は `true` を返す.
-func (e *wrappingError) As(target interface{}) bool {
+func (e *wrappingError) As(target any) bool {
 	return As(e.main, target) || As(e.cause, target)
 }
 

--- a/multiple.go
+++ b/multiple.go
@@ -38,7 +38,7 @@ func NewMultipleError(errs ...error) *MultipleError {
 // `m.errs` that is assignable to it.
 //
 // As は `m.errs` の中に `target` に代入可能な最初の要素があれば代入して `true` を返す.
-func (m *MultipleError) As(target interface{}) bool {
+func (m *MultipleError) As(target any) bool {
 	for _, err := range m.errs {
 		if As(err, target) {
 			return true

--- a/std.go
+++ b/std.go
@@ -5,7 +5,7 @@ import "errors"
 // As just calls standard `errors.As`.
 //
 // As は標準の `errors.As` を呼び出すだけ.
-func As(err error, target interface{}) bool {
+func As(err error, target any) bool {
 	return errors.As(err, target)
 }
 

--- a/with_param.go
+++ b/with_param.go
@@ -8,7 +8,7 @@ package errors
 // `errors.As` で判定できるように型は公開しておく.
 type WithParamsError struct {
 	err error
-	ps  []interface{}
+	ps  []any
 }
 
 var _ stdError = (*WithParamsError)(nil)
@@ -18,7 +18,7 @@ var _ stdError = (*WithParamsError)(nil)
 //
 // NewWithParamsError は新規の `WithParamsError` を生成する.
 // 引数の `err` が `nil` の場合は `nil` が返される.
-func NewWithParamsError(err error, ps ...interface{}) *WithParamsError {
+func NewWithParamsError(err error, ps ...any) *WithParamsError {
 	if err == nil {
 		return nil
 	}
@@ -29,7 +29,7 @@ func NewWithParamsError(err error, ps ...interface{}) *WithParamsError {
 // As returns `true` and assign `e.err` if the `target` can be assigned.
 //
 // As は `e.err` が `target` に代入可能であれば代入して `true` を返す.
-func (e *WithParamsError) As(target interface{}) bool {
+func (e *WithParamsError) As(target any) bool {
 	return As(e.err, target)
 }
 
@@ -57,6 +57,6 @@ func (e *WithParamsError) Unwrap() error {
 // Params returns the parameters given at creation time.
 //
 // Params は生成時に与えられたパラメータを返す.
-func (e *WithParamsError) Params() []interface{} {
+func (e *WithParamsError) Params() []any {
 	return e.ps
 }


### PR DESCRIPTION
This pull request updates the codebase to use the Go 1.18+ `any` type instead of `interface{}` for type parameters and arguments. It also upgrades several GitHub Actions to their latest major versions for improved reliability and security.

**Migration to `any` type:**

* Replaced all instances of `interface{}` with `any` in function signatures, type definitions, and method implementations across `error.go`, `multiple.go`, and `with_param.go` to align with modern Go best practices. [[1]](diffhunk://#diff-097efd4fdcfbc4644e1d6fd6b758f217ca51969e14309c8b70d42a6e41dde579L5-R12) [[2]](diffhunk://#diff-097efd4fdcfbc4644e1d6fd6b758f217ca51969e14309c8b70d42a6e41dde579L46-R46) [[3]](diffhunk://#diff-f36ab09e5c7aff52cf58ff49edde423e0b2540f3e0583510f26e1d0a58634b72L41-R41) [[4]](diffhunk://#diff-260a6cd49d76f3e90b6b05c19bd8765b10cb92bd64761c860f3b9d9eddc76d1bL8-R8) [[5]](diffhunk://#diff-ca70155250cc7f44285fa2226f927d8e91426e07f45ea82796cd421a116ad9f8L11-R11) [[6]](diffhunk://#diff-ca70155250cc7f44285fa2226f927d8e91426e07f45ea82796cd421a116ad9f8L21-R21) [[7]](diffhunk://#diff-ca70155250cc7f44285fa2226f927d8e91426e07f45ea82796cd421a116ad9f8L32-R32) [[8]](diffhunk://#diff-ca70155250cc7f44285fa2226f927d8e91426e07f45ea82796cd421a116ad9f8L60-R60)

**CI/CD maintenance:**

* Upgraded `actions/checkout` from v5.0.0 to v6.0.0 in `.github/workflows/check-code.yaml` and `.github/workflows/scan-vulnerabilities.yaml` for all jobs. [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L20-R22) [[2]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L34-R34) [[3]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L49-R51) [[4]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL18-R20)
* Upgraded `golangci/golangci-lint-action` from v8.0.0 to v9.1.0 in `.github/workflows/check-code.yaml`.
* Upgraded `actions/setup-go` from v6.0.0 to v6.1.0 in `.github/workflows/check-code.yaml` and `.github/workflows/scan-vulnerabilities.yaml`. [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L49-R51) [[2]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL18-R20)